### PR TITLE
Started TimeOfDaySliderTests

### DIFF
--- a/RushHourTests/MockClasses/UIHelperBaseStub.cs
+++ b/RushHourTests/MockClasses/UIHelperBaseStub.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RushHour.UI;
+using CimTools.V1.Utilities;
+using ICities;
+
+namespace RushHourTests.MockClasses
+{
+    class UIHelperBaseStub : UIHelperBase
+    {
+        public object AddButton(string text, OnButtonClicked eventCallback)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object AddCheckbox(string text, bool defaultValue, OnCheckChanged eventCallback)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object AddDropdown(string text, string[] options, int defaultSelection, OnDropdownSelectionChanged eventCallback)
+        {
+            throw new NotImplementedException();
+        }
+
+        public UIHelperBase AddGroup(string text)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object AddSlider(string text, float min, float max, float step, float defaultValue, OnValueChanged eventCallback)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object AddSpace(int height)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object AddTextfield(string text, string defaultContent, OnTextChanged eventChangedCallback, OnTextSubmitted eventSubmittedCallback = null)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/RushHourTests/MockClasses/UnityEngineOverrides.cs
+++ b/RushHourTests/MockClasses/UnityEngineOverrides.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RushHourTests.MockClasses
+{
+    // Idea borrowed from http://forum.unity3d.com/threads/security-exception-ecall-methods-must-be-packaged-into-a-system-module.98230/
+    // See also http://forum.unity3d.com/threads/networkserver-in-console-application.362012/
+    // and http://forum.unity3d.com/threads/c-console-server-ecall-error.50163/
+    // http://www.amitloaf.com/2014/02/continuous-integration-and-unit-tests_12.html
+    // and http://stackoverflow.com/questions/11286004/securityexception-ecall-methods-must-be-packaged-into-a-system-module
+    // and http://answers.unity3d.com/questions/628962/why-cant-we-use-unityenginedll-outside-of-unity.html
+    // :(
+    public class Debug
+    {
+        public static void Log(string s) { Console.WriteLine(s); }
+        public static void LogWarning(string s) { Console.WriteLine(s); }
+        public static void LogError(string s) { Console.WriteLine(s); }
+    }
+
+    public class MonoBehaviour
+    {
+
+    }
+}

--- a/RushHourTests/RushHourTests.csproj
+++ b/RushHourTests/RushHourTests.csproj
@@ -35,6 +35,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CimTools, Version=1.0.5895.27347, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\RushHour\CimTools\CimTools.dll</HintPath>
+    </Reference>
+    <Reference Include="ICities, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ICities.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.XML" />
   </ItemGroup>
@@ -52,7 +60,10 @@
   </Choose>
   <ItemGroup>
     <Compile Include="BasicTests.cs" />
+    <Compile Include="MockClasses\UIHelperBaseStub.cs" />
+    <Compile Include="MockClasses\UnityEngineOverrides.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TimeOfDaySliderTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RushHour\RushHour.csproj">

--- a/RushHourTests/TimeOfDaySliderTests.cs
+++ b/RushHourTests/TimeOfDaySliderTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RushHour.UI;
+using CimTools.V1.Utilities;
+using ICities;
+using RushHourTests.MockClasses;
+
+namespace RushHourTests
+{
+    [TestClass]
+    public class TimeOfDaySliderTests
+    {
+        [TestMethod]
+        public void TestGetAndSetValue()
+        {
+            // Commented lines throw System.Security.SecurityException: ECall methods must be packaged into a system module.
+            // because we use UnityEngine underneath :( - I think we need to rewrite components for better testability with
+            // less reliance on Unity stuff where possible, or using DI so we can pass in a stub to use.
+            //UIHelperBase _base = new UIHelperBaseStub();
+            TimeOfDaySlider _slider = new TimeOfDaySlider();
+
+            //_slider.Create(_base);
+
+            _slider.value = 5;
+            Assert.AreEqual(5f, _slider.value);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(NullReferenceException))]
+        public void TestGetValueThrowsIfNotSet()
+        {
+            TimeOfDaySlider _slider = new TimeOfDaySlider();
+            Assert.AreEqual("12", _slider.value);
+        }
+
+        [TestMethod]
+        public void TestToStringReturnsClassName()
+        {
+            TimeOfDaySlider _slider = new TimeOfDaySlider();
+            Assert.AreEqual("RushHour.UI.TimeOfDaySlider", _slider.ToString());
+        }
+    }
+
+}


### PR DESCRIPTION
This was a pleasure to get started with but I quickly hit a wall with a thrown `System.Security.SecurityException: ECall methods must be packaged into a system module.` apparently because we use UnityEngine underneath and it wants the Unity C++ runtime but we're only in visual studio testing C#.

I tried a few things after reading these sorts of links:
- http://forum.unity3d.com/threads/security-exception-ecall-methods-must-be-packaged-into-a-system-module.98230/
- http://forum.unity3d.com/threads/networkserver-in-console-application.362012/
- http://forum.unity3d.com/threads/c-console-server-ecall-error.50163/
- http://www.amitloaf.com/2014/02/continuous-integration-and-unit-tests_12.html
- http://stackoverflow.com/questions/11286004/securityexception-ecall-methods-must-be-packaged-into-a-system-module
- http://answers.unity3d.com/questions/628962/why-cant-we-use-unityenginedll-outside-of-unity.html

I think I'd like to to rewrite the component for to have less reliance on Unity stuff where possible, perhaps by passing in a dependency that can be Unity or can be a mocked object, a.k.a. constructor dependency injection. Currently I can't get past `.Create` throwing this error and am having trouble debugging in to see what line is triggering it.

Until then, we can use the component and test it otherwise, so that's what I've done, but I've included the other stuff in the hopes you have some ideas on how to get it going. :)

The currently not used files are `RushHourTests/MockClasses/UIHelperBaseStub.cs` and `RushHourTests/MockClasses/UnityEngineOverrides.cs`.
