### PR TITLE
Broke out slider value -> label logic for testing & fixed initial too…

### DIFF
--- a/RushHour/UI/TimeOfDaySlider.cs
+++ b/RushHour/UI/TimeOfDaySlider.cs
@@ -32,7 +32,7 @@ namespace RushHour.UI
             UISlider slider = helper.AddSlider(this.readableName, this.min, this.max, this.step, this.value, IgnoredFunction) as UISlider;
             slider.enabled = this.enabled;
             slider.name = this.uniqueName;
-            slider.tooltip = this.value.ToString();
+            slider.tooltip = this.getTimeFromFloatingValue(this.value);
             slider.width = 500f;
 
             UIPanel sliderParent = slider.parent as UIPanel;
@@ -49,17 +49,24 @@ namespace RushHour.UI
             slider.eventValueChanged += delegate (UIComponent component, float newValue)
             {
                 this.value = newValue;
-                float displayedValue = this.value % 12; // Wrap military time into civilian time
-                if ( displayedValue < 1f ) {
-                    displayedValue += 12f; // Instead of 0 let's show 12 even for am
-                }
-                int hours = (int)(displayedValue);
-                string minutes = string.Format("{0:00}", (int)((displayedValue % 1f) * 60f));
-                string suffix = (this.value * one_over_twelve > 1 ) ? "pm" : "am";
-
-                slider.tooltip = hours.ToString() + ':' + minutes.ToString() + ' ' + suffix;
+                slider.tooltip = this.getTimeFromFloatingValue(this.value);
                 slider.RefreshTooltip();
             };
+
+        }
+
+        private string getTimeFromFloatingValue(float value)
+        {
+            float displayedValue = value % 12; // Wrap military time into civilian time
+            if (displayedValue < 1f)
+            {
+                displayedValue += 12f; // Instead of 0 let's show 12 even for am
+            }
+            int hours = (int)(displayedValue);
+            string minutes = string.Format("{0:00}", (int)((displayedValue % 1f) * 60f));
+            string suffix = (value * one_over_twelve > 1) ? "pm" : "am";
+
+            return hours.ToString() + ':' + minutes.ToString() + ' ' + suffix;
         }
     }
 }

--- a/RushHour/UI/TimeOfDayVarianceSlider.cs
+++ b/RushHour/UI/TimeOfDayVarianceSlider.cs
@@ -32,7 +32,7 @@ namespace RushHour.UI
             UISlider slider = helper.AddSlider(this.readableName, this.min, this.max, this.step, this.value, IgnoredFunction) as UISlider;
             slider.enabled = this.enabled;
             slider.name = this.uniqueName;
-            slider.tooltip = this.value.ToString();
+            slider.tooltip = this.getVarianceTimeFromFloatingValue(this.value);
             slider.width = 500f;
 
             UIPanel sliderParent = slider.parent as UIPanel;
@@ -49,36 +49,44 @@ namespace RushHour.UI
             slider.eventValueChanged += delegate (UIComponent component, float newValue)
             {
                 this.value = newValue;
-                float displayedValue = this.value; // Wrap military time into civilian time
-                int hours = (int)(displayedValue);
-                int minutes = (int)((displayedValue % 1f) * 60f);
-                string minutesString = string.Format("{0:00}", minutes);
-
-                string strings = "";
-                if (hours != 0) {
-                    strings += string.Format("{0} hour", hours.ToString());
-                    if ( hours > 1 ) {
-                        strings += "s"; // Pluralize
-                    }
-                }
-                if (minutes != 0) {
-                    if (strings != "")
-                    {
-                        strings += " and ";
-                    }
-                    strings += string.Format("{0} minute", minutesString);
-                    if (minutes > 1)
-                    {
-                        strings += "s"; // Pluralize
-                    }
-                }
-                if ( strings == "" )
-                {
-                    strings = "No Variance";
-                }
-                slider.tooltip = strings;
+                slider.tooltip = this.getVarianceTimeFromFloatingValue(this.value);
                 slider.RefreshTooltip();
             };
+
+        }
+
+        private string getVarianceTimeFromFloatingValue(float value)
+        {
+            int hours = (int)(value);
+            int minutes = (int)((value % 1f) * 60f);
+            string minutesString = string.Format("{0:00}", minutes);
+
+            string strings = "";
+            if (hours != 0)
+            {
+                strings += string.Format("{0} hour", hours.ToString());
+                if (hours > 1)
+                {
+                    strings += "s"; // Pluralize
+                }
+            }
+            if (minutes != 0)
+            {
+                if (strings != "")
+                {
+                    strings += " and ";
+                }
+                strings += string.Format("{0} minute", minutesString);
+                if (minutes > 1)
+                {
+                    strings += "s"; // Pluralize
+                }
+            }
+            if (strings == "")
+            {
+                strings = "No Variance";
+            }
+            return strings;
         }
     }
 }

--- a/RushHourTests/RushHourTests.csproj
+++ b/RushHourTests/RushHourTests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="MockClasses\UnityEngineOverrides.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TimeOfDaySliderTests.cs" />
+    <Compile Include="TimeOfDayVarianceSliderTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RushHour\RushHour.csproj">

--- a/RushHourTests/TimeOfDaySliderTests.cs
+++ b/RushHourTests/TimeOfDaySliderTests.cs
@@ -39,6 +39,114 @@ namespace RushHourTests
             TimeOfDaySlider _slider = new TimeOfDaySlider();
             Assert.AreEqual("RushHour.UI.TimeOfDaySlider", _slider.ToString());
         }
+
+        [TestMethod]
+        public void TestGetTimeFromFloatingValueDetectsEarlyMorning()
+        {
+            PrivateObject privateHelperObject = new PrivateObject(typeof(TimeOfDaySlider));
+            float newValue = 3f;
+            string expectedValue = "3:00 am";
+
+            string actualValue = (string)privateHelperObject.Invoke("getTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        [TestMethod]
+        public void TestGetTimeFromFloatingValueDetectsExtremelyEarlyMorning()
+        {
+            PrivateObject privateHelperObject = new PrivateObject(typeof(TimeOfDaySlider));
+            float newValue = 0.17f;
+            string expectedValue = "12:10 am";
+
+            string actualValue = (string)privateHelperObject.Invoke("getTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        [TestMethod]
+        public void TestGetTimeFromFloatingValueDetectsNoonAkaLunchTime()
+        {
+            PrivateObject privateHelperObject = new PrivateObject(typeof(TimeOfDaySlider));
+            float newValue = 12.0f;
+            string expectedValue = "12:00 pm";
+
+            string actualValue = (string)privateHelperObject.Invoke("getTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        [TestMethod]
+        public void TestGetTimeFromFloatingValueDetectsExtremelyLateNight()
+        {
+            PrivateObject privateHelperObject = new PrivateObject(typeof(TimeOfDaySlider));
+            float newValue = 23.8f;
+            string expectedValue = "11:47 pm";
+
+            string actualValue = (string)privateHelperObject.Invoke("getTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        [TestMethod]
+        public void TestGetTimeFromFloatingValueDetectsMostExtremeLateNight()
+        {
+            PrivateObject privateHelperObject = new PrivateObject(typeof(TimeOfDaySlider));
+            float newValue = 23.9f;
+            string expectedValue = "11:53 pm";
+
+            string actualValue = (string)privateHelperObject.Invoke("getTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+            
+            newValue = 23.999f;
+            expectedValue = "11:59 pm";
+
+            actualValue = (string)privateHelperObject.Invoke("getTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        [TestMethod]
+        public void TestGetTimeFromFloatingValueRounds()
+        {
+            PrivateObject privateHelperObject = new PrivateObject(typeof(TimeOfDaySlider));
+            float newValue = 12.49999f;
+            string expectedValue = "12:29 pm";
+
+            string actualValue = (string)privateHelperObject.Invoke("getTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+
+            newValue = 12.49999999999999f;
+            expectedValue = "12:30 pm";
+
+            actualValue = (string)privateHelperObject.Invoke("getTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+
+            newValue = 12.500000f;
+            expectedValue = "12:30 pm";
+
+            actualValue = (string)privateHelperObject.Invoke("getTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+
+            newValue = 12.500111f;
+            expectedValue = "12:30 pm";
+
+            actualValue = (string)privateHelperObject.Invoke("getTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+
+            newValue = 12.511111f;
+            expectedValue = "12:30 pm";
+
+            actualValue = (string)privateHelperObject.Invoke("getTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+
+            newValue = 12.516f;
+            expectedValue = "12:30 pm";
+
+            actualValue = (string)privateHelperObject.Invoke("getTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+
+            newValue = 12.517f;
+            expectedValue = "12:31 pm";
+
+            actualValue = (string)privateHelperObject.Invoke("getTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+        }
     }
 
 }

--- a/RushHourTests/TimeOfDayVarianceSliderTests.cs
+++ b/RushHourTests/TimeOfDayVarianceSliderTests.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RushHour.UI;
+using CimTools.V1.Utilities;
+using ICities;
+using RushHourTests.MockClasses;
+
+namespace RushHourTests
+{
+    [TestClass]
+    public class TimeOfDayVarianceSliderTests
+    {
+        [TestMethod]
+        public void TestGetAndSetValue()
+        {
+            // Commented lines throw System.Security.SecurityException: ECall methods must be packaged into a system module.
+            // because we use UnityEngine underneath :( - I think we need to rewrite components for better testability with
+            // less reliance on Unity stuff where possible, or using DI so we can pass in a stub to use.
+            //UIHelperBase _base = new UIHelperBaseStub();
+            TimeOfDayVarianceSlider _slider = new TimeOfDayVarianceSlider();
+
+            //_slider.Create(_base);
+
+            _slider.value = 5;
+            Assert.AreEqual(5f, _slider.value);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(NullReferenceException))]
+        public void TestGetValueThrowsIfNotSet()
+        {
+            TimeOfDayVarianceSlider _slider = new TimeOfDayVarianceSlider();
+            Assert.AreEqual("12", _slider.value);
+        }
+
+        [TestMethod]
+        public void TestToStringReturnsClassName()
+        {
+            TimeOfDayVarianceSlider _slider = new TimeOfDayVarianceSlider();
+            Assert.AreEqual("RushHour.UI.TimeOfDayVarianceSlider", _slider.ToString());
+        }
+
+        [TestMethod]
+        public void TestGetTimeFromFloatingValueDetectsEarlyMorning()
+        {
+            PrivateObject privateHelperObject = new PrivateObject(typeof(TimeOfDayVarianceSlider));
+            float newValue = 3f;
+            string expectedValue = "3 hours";
+
+            string actualValue = (string)privateHelperObject.Invoke("getVarianceTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        [TestMethod]
+        public void TestGetTimeFromFloatingValueDetectsExtremelyEarlyMorning()
+        {
+            PrivateObject privateHelperObject = new PrivateObject(typeof(TimeOfDayVarianceSlider));
+            float newValue = 0.17f;
+            string expectedValue = "10 minutes";
+
+            string actualValue = (string)privateHelperObject.Invoke("getVarianceTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+        
+        [TestMethod]
+        public void TestGetTimeFromFloatingValueDoesNotWrapGreaterThanHours()
+        {
+            PrivateObject privateHelperObject = new PrivateObject(typeof(TimeOfDayVarianceSlider));
+            float newValue = 123.999f;
+            string expectedValue = "123 hours and 59 minutes";
+
+            string actualValue = (string)privateHelperObject.Invoke("getVarianceTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+
+        [TestMethod]
+        public void TestGetTimeFromFloatingValueRounds()
+        {
+            PrivateObject privateHelperObject = new PrivateObject(typeof(TimeOfDayVarianceSlider));
+            float newValue = 12.49999f;
+            string expectedValue = "12 hours and 29 minutes";
+
+            string actualValue = (string)privateHelperObject.Invoke("getVarianceTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+
+            newValue = 12.49999999999999f;
+            expectedValue = "12 hours and 30 minutes";
+
+            actualValue = (string)privateHelperObject.Invoke("getVarianceTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+
+            newValue = 12.500000f;
+            expectedValue = "12 hours and 30 minutes";
+
+            actualValue = (string)privateHelperObject.Invoke("getVarianceTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+
+            newValue = 12.500111f;
+            expectedValue = "12 hours and 30 minutes";
+
+            actualValue = (string)privateHelperObject.Invoke("getVarianceTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+
+            newValue = 12.511111f;
+            expectedValue = "12 hours and 30 minutes";
+
+            actualValue = (string)privateHelperObject.Invoke("getVarianceTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+
+            newValue = 12.516f;
+            expectedValue = "12 hours and 30 minutes";
+
+            actualValue = (string)privateHelperObject.Invoke("getVarianceTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+
+            newValue = 12.517f;
+            expectedValue = "12 hours and 31 minutes";
+
+            actualValue = (string)privateHelperObject.Invoke("getVarianceTimeFromFloatingValue", newValue);
+            Assert.AreEqual(expectedValue, actualValue);
+        }
+    }
+}


### PR DESCRIPTION
Broke out slider value -> label logic for testing & fixed initial tooltip value
- Initial tooltip values were displaying integer such as "3" instead of correct value such as "3 hours". They would fix upon value change. They now show the correct value initially.
- Added test file for TimeOfDayVarianceSlider
  - Tests now cover the meat of the TimeOfDay*Slider subclasses
